### PR TITLE
fix(api): fix express json import crash in production

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -3,14 +3,14 @@ import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import helmet from 'helmet';
-import express from 'express';
+import { json } from 'express';
 import { AppModule } from './app.module';
 import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  app.use(express.json({ limit: '100kb' }));
+  app.use(json({ limit: '100kb' }));
 
   app.use(
     helmet({


### PR DESCRIPTION
Named import `json` from express instead of default import which is undefined in the NestJS CJS build, causing bootstrap crash.